### PR TITLE
Move to a route for spotify as opposed to domain

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,5 +1,4 @@
 CLIENT_ID="SPOTIFY_APP_ID"
 CLIENT_SECRET="SPOTIFY_APP_CLIENT"
-REDIRECT_URI="http://127.0.0.1:8787/callback" # cannot be localhost due to spotify restrictions
-COOKIE_DOMAIN="" # set on production so the subdomain carries the cookie, so in my case .mcgoooo-world
+REDIRECT_URI="http://127.0.0.1:8787/spotify/callback" # cannot be localhost due to spotify restrictions
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { Env } from "./types/Env";
 
 const app = new Hono<{ Bindings: Env }>();
 [loginRoute, callbackRoute, currentUserRoute,currentUserPlaylistsRoute].forEach((route) => {
-  app.route("/", route);
+  app.route("/spotify", route);
 });
 
 export default app;

--- a/src/requests/spotify/api/spotifyUser/playlists.ts
+++ b/src/requests/spotify/api/spotifyUser/playlists.ts
@@ -1,4 +1,3 @@
-import { SpotifyUser } from "../../../../types/SpotifyUser";
 import { SpotifyPlaylistResponse } from "../../../../types/SpotifyUser/Playlist";
 import { spotifyHeaders } from "../../utils/fetch";
 import { spotifyUserPlaylistUrl } from "../../utils/url";
@@ -15,5 +14,5 @@ export const spotifyUserPlaylists = async (
   }
   const data = (await response.json());
   
-  return data as SpotifyUser;
+  return data as SpotifyPlaylistResponse;
 }

--- a/src/routes/callback.ts
+++ b/src/routes/callback.ts
@@ -18,9 +18,7 @@ callbackRoute.get("/callback", async (c) => {
     c.req.query("code")!,
   );
   const cookieOptions: { domain?: string; secure: boolean } = { secure: true };
-  if (getEnvKey(c, "COOKIE_DOMAIN"))
-    cookieOptions.domain = getEnvKey(c, "COOKIE_DOMAIN");
-  console.log(tokenJson)
+
   setCookie(c, "spotify_access_token", tokenJson.access_token, cookieOptions);
   setCookie(c, "spotify_refresh_token", tokenJson.refresh_token, cookieOptions);
   const returnTo = getCookie(c, "return_to");

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -2,5 +2,4 @@ export type Env = {
   CLIENT_ID: string;
   CLIENT_SECRET: string;
   REDIRECT_URI: string;
-  COOKIE_DOMAIN: string;
 };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,33 +4,10 @@
   "main": "src/index.ts",
   "compatibility_date": "2025-08-08",
   "compatibility_flags": ["nodejs_compat"],
-  // "vars": {
-  //   "MY_VAR": "my-variable"
-  // },
-  // "kv_namespaces": [
-  //   {
-  //     "binding": "MY_KV_NAMESPACE",
-  //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-  //   }
-  // ],
-  // "r2_buckets": [
-  //   {
-  //     "binding": "MY_BUCKET",
-  //     "bucket_name": "my-bucket"
-  //   }
-  // ],
-  // "d1_databases": [
-  //   {
-  //     "binding": "MY_DB",
-  //     "database_name": "my-database",
-  //     "database_id": ""
-  //   }
-  // ],
-  // "ai": {
-  //   "binding": "AI"
-  // },
-  "observability": {
-    "enabled": true,
-    "head_sampling_rate": 1,
-  },
+  "routes": [
+    {
+      "pattern": "mcgoooo.world/spotify*",
+      "zone_id": "892dc314a0debe0796a0786f92aa4348"
+    },
+  ]
 }


### PR DESCRIPTION
Cookie handling was a chore because of the sub domain particularly safari, it was a small hack to get started.

Basically, chrome allows third party cookeis, and safari does not. So it did not work on safari.

The concept of the cloudflare routing is here

https://developers.cloudflare.com/workers/configuration/routing/routes/